### PR TITLE
Feature etc adaptative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@ Changelog
 0.4.0
 -----
 
-- It's possible to use config file from `/etc/update-conf.py.conf` or `~/.update-conf.py.conf`;
-- Bugfix: Skipping global config file when instaling from a non-privileged user;
-    - If isn't possible to create the `/etc/update-conf.py.conf` file, a warning will be showed instead of stopping the install.
-- Sample config file installed in `{prefix}/share/update-conf.py.conf`.
+- It's possible to use a user home config file (`~/.update-conf.py.conf`);
+- **Fix:** Skip copy of system config file (`/etc/update-conf.py.conf`) when installing using a non-privileged user;
+- Project data in `{prefix}/share/update-conf.py`;
+    - For now, only the sample config file is being put there.
 
 0.3.4
 -----
 
-- First release in Pypi;
-- First stable version.
+- First release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+Changelog
+=========
+
+0.4.0
+-----
+
+- It's possible to use config file from `/etc/update-conf.py.conf` or `~/.update-conf.py.conf`;
+- Bugfix: Skipping global config file when instaling from a non-privileged user;
+    - If isn't possible to create the `/etc/update-conf.py.conf` file, a warning will be showed instead of stopping the install.
+- Sample config file installed in `{prefix}/share/update-conf.py.conf`.
+
+0.3.4
+-----
+
+- First release in Pypi;
+- First stable version.

--- a/README.md
+++ b/README.md
@@ -81,10 +81,5 @@ This software is released under the [Revised BSD License](LICENSE).
 TODO
 ----
 
-- Problems with the config file install;
-    - It can generate errors while instaling the project in a local env, or using `--user`;
-    - A think the application should search for a config file in `/etc` or in `sys.prefix/etc`;
-    - See: http://stackoverflow.com/questions/7567642/where-to-put-a-configuration-file-in-python;
-    - See: https://pythonhosted.org/mrjob/guides/configs-basics.html;
 - Publish this software in a Ubuntu PPA;
     - Ubuntu 12.04 and Ubuntu 14.04.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install
 
 This project requires Python 2.6 or newer.
 
-**PS:** It's possible to use Python 3. However, it is not well tested.
+**PS:** It's possible to use Python 3 also. However, it is not well tested.
 
 In Ubuntu/Debian:
 
@@ -28,7 +28,7 @@ To install:
 pip install update-conf.py
 ```
 
-It's also possible to clone the project in Github and install via `setuptools`:
+It's possible to clone the project in Github and install it via `setuptools`:
 
 ```sh
 git clone git@github.com:rarylson/update-conf.py.git
@@ -77,6 +77,11 @@ License
 -------
 
 This software is released under the [Revised BSD License](LICENSE).
+
+Changelog
+---------
+
+You can see the changelog [here](CHANGELOG.md).
 
 TODO
 ----

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,13 @@ class GenerateRstCommand(Command):
             # However, we do not want these links in Pypi (they will be
             # broken). We want to replace them by absolutive URLs (like
             # [Page]({url}/blob/master/page)).
-            # For now, the conversions are hardcoded
+            # For now, the conversions are hardcoded.
             md_link_re = r"\(LICENSE\)"
             md_link_new = r"({0}/blob/master/LICENSE)".format(GITHUB_URL)
             new_md = re.sub(md_link_re, md_link_new, md)
+            md_link_re = r"\(CHANGELOG\.md\)"
+            md_link_new = r"({0}/blob/master/CHANGELOG.md)".format(GITHUB_URL)
+            new_md = re.sub(md_link_re, md_link_new, new_md)
             with open(tmp_readme_md, "w") as f:
                 f.write(new_md)
             # Now, convert to RST

--- a/tests/config/user-update-conf.py.conf
+++ b/tests/config/user-update-conf.py.conf
@@ -1,0 +1,5 @@
+# Config file used in tests
+# This config file MUST be used from the project root dir.
+
+[test1]
+file = /nonexistent/home

--- a/tests/test_get_splitted.py
+++ b/tests/test_get_splitted.py
@@ -49,7 +49,7 @@ class GetSplittedTest(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 main._get_splitted("/non-existent")
             output = sys.stderr.getvalue()
-            self.assertTrue("Dir" in output and "not found" in output)
+            self.assertTrue("dir" in output and "not found" in output)
         finally:
             sys.stderr = stderr_old
         # Empty dir
@@ -58,7 +58,7 @@ class GetSplittedTest(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 main._get_splitted(utils.TMP_DIR)
             output = sys.stderr.getvalue()
-            self.assertTrue("No splitted" in output and "found" in output)
+            self.assertTrue("no splitted" in output and "found" in output)
         finally:
             sys.stderr = stderr_old
 

--- a/tests/test_parse_all.py
+++ b/tests/test_parse_all.py
@@ -61,7 +61,7 @@ class ParseAllTest(unittest.TestCase):
         self.assertEqual(args.file, self.file_path)
         self.assertEqual(args.dir, "{0}.d".format(self.file_path))
         self.assertEqual(args.comment_prefix, "#")
-        self.assertEqual(args.config, "/etc/update-conf.py.conf")
+        self.assertEqual(args.config, [main.SYSTEM_CONFIG, main.USER_CONFIG])
 
     def test_wrong_cmd_args(self):
         """App must print an error and exit on wrong cmd args

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,4 +1,3 @@
-import sys
 import os
 from os.path import join
 import subprocess
@@ -10,7 +9,7 @@ import utils
 
 
 class ScriptTest(unittest.TestCase):
-    """Tests uing the final script
+    """Tests that use the final script
     """
 
     def setUp(self):

--- a/tests/test_sudo_config.py
+++ b/tests/test_sudo_config.py
@@ -1,0 +1,93 @@
+import sys
+import os
+from os.path import join, isfile
+import shutil
+from StringIO import StringIO
+
+import unittest
+
+from update_conf_py import main
+
+import utils
+
+
+@unittest.skipIf(
+    os.geteuid() != 0, "supported only if the user is a superuser")
+class SudoConfigTest(unittest.TestCase):
+    """Tests for the config read feature, but that requires superuser
+    privileges
+
+    This tests SHOULD be run only in DEVELOPMENT envs. There are risks of
+    destroying your original config files. Keep CAUTION!
+    """
+
+    def setUp(self):
+        self.section_name = "test1"
+        self.expected_file_global = "tests/tmp/test1"
+        self.expected_file_user = "/nonexistent/home"
+        self.backup_global = join(utils.TMP_DIR, "config_global.bak")
+        self.backup_user = join(utils.TMP_DIR, "config_user.bak")
+        utils.clean_tmp()
+        # Mock 'argv' with the new cmd args
+        self.argv_old = sys.argv
+        sys.argv = [sys.argv[0], "-n", self.section_name]
+        # Move/backup original config files
+        if isfile(main.SYSTEM_CONFIG):
+            shutil.move(main.SYSTEM_CONFIG, self.backup_global)
+        if isfile(main.USER_CONFIG):
+            shutil.move(main.USER_CONFIG, self.backup_user)
+
+    def tearDown(self):
+        sys.argv = self.argv_old
+        # Clean config files. If they exist, they are test files.
+        if isfile(main.SYSTEM_CONFIG):
+            os.remove(main.SYSTEM_CONFIG)
+        if isfile(main.USER_CONFIG):
+            os.remove(main.USER_CONFIG)
+        # Restore original config files
+        if isfile(self.backup_global):
+            shutil.move(self.backup_global, main.SYSTEM_CONFIG)
+        if isfile(self.backup_user):
+            shutil.move(self.backup_user, main.USER_CONFIG)
+
+    def test_system_config(self):
+        """App must read config file from system etc if it exits
+        """
+        shutil.copy(utils.CONF_FILE, main.SYSTEM_CONFIG)
+        args = main._parse_all()
+        self.assertEqual(args.file, self.expected_file_global)
+
+    def test_user_config(self):
+        """App must read config file from user home if it exits
+        """
+        shutil.copy(utils.USER_CONF_FILE, main.USER_CONFIG)
+        args = main._parse_all()
+        self.assertEqual(args.file, self.expected_file_user)
+
+    def test_system_user_config(self):
+        """Options from user config file MUST take precedence over the
+        system one
+        """
+        shutil.copy(utils.CONF_FILE, main.SYSTEM_CONFIG)
+        shutil.copy(utils.USER_CONF_FILE, main.USER_CONFIG)
+        args = main._parse_all()
+        self.assertEqual(args.file, self.expected_file_user)
+
+    def test_default_config_not_found(self):
+        """App must print a error if none of the default config files were
+        found
+        """
+        stderr_old, sys.stderr = sys.stderr, StringIO()
+        try:
+            with self.assertRaises(SystemExit):
+                main._parse_all()
+            output = sys.stderr.getvalue()
+            self.assertTrue(
+                "neither" in output and "nor" in output and
+                main.SYSTEM_CONFIG in output and main.USER_CONFIG in output)
+        finally:
+            sys.stderr = stderr_old
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,6 +13,7 @@ TESTS_DIR = abspath(dirname(__file__))
 SNIPPETS_DIR = join(TESTS_DIR, "snippets")
 TMP_DIR = join(TESTS_DIR, "tmp")
 CONF_FILE = join(TESTS_DIR, "config", "update-conf.py.conf")
+USER_CONF_FILE = join(TESTS_DIR, "config", "user-update-conf.py.conf")
 RESULTS_DIR = join(TESTS_DIR, "expected_results")
 ROOT_DIR = join(TESTS_DIR, os.pardir)
 

--- a/update_conf_py/main.py
+++ b/update_conf_py/main.py
@@ -179,10 +179,10 @@ def _get_splitted(directory):
                 splitted_files.append(entry_path)
     # Dir not found error
     except OSError:
-        _error("Dir '{0}' not found".format(directory))
+        _error("dir '{0}' not found".format(directory))
     # No splitted files error
     if not splitted_files:
-        _error("No splitted files found in dir '{0}'".format(directory))
+        _error("no splitted files found in dir '{0}'".format(directory))
 
     return splitted_files
 

--- a/update_conf_py/main.py
+++ b/update_conf_py/main.py
@@ -20,11 +20,13 @@ from ConfigParser import SafeConfigParser
 __author__ = "Rarylson Freitas"
 __email__ = "rarylson@gmail.com"
 __program__ = "update-conf.py"
-__version__ = "0.3.4"
+__version__ = "0.4.0"
 __license__ = "Revised BSD"
 
 # Consts
-DEFAULT_CONFIG = "/etc/{0}.conf".format(__program__)
+CONFIG_NAME = "{0}.conf".format(__program__)
+SYSTEM_CONFIG = os.path.join("/etc", CONFIG_NAME)
+USER_CONFIG = os.path.join(os.path.expanduser("~"), ".{0}".format(CONFIG_NAME))
 DEFAULT_DIR_EXT = "d"
 DEFAULT_COMMENT_PREFIX = "#"
 IGNORE_FILES_EXT = ["bak", "backup", "old", "inactive", "disabled"]
@@ -89,9 +91,8 @@ def _parse_all():
         help="name of the section (defined in the config file) to be used")
     parser.add_argument(
         "-c", "--config",
-        help="{0} config file (default {0})".format(
-            __program__, DEFAULT_CONFIG),
-        default=DEFAULT_CONFIG)
+        help="{0} config file (default [{1}, {2}])".format(
+            __program__, SYSTEM_CONFIG, USER_CONFIG))
     parser.add_argument(
         "-p", "--comment-prefix",
         help="Prefix to be used in the auto-generated comment (default '#')")
@@ -107,11 +108,21 @@ def _parse_all():
     # Parse config file
     if args.name:
         config_parser = SafeConfigParser()
-        # Open config file
-        try:
-            config_parser.readfp(open(args.config, 'r'))
-        except IOError:
-            parser.error("config file '{}' not found".format(args.config))
+        # Specific config file
+        if args.config:
+            try:
+                config_parser.readfp(open(args.config, 'r'))
+            except IOError:
+                parser.error("config file '{0}' not found".format(args.config))
+        # Default config file
+        # Options from USER_CONFIG take precedence over SYSTEM_CONFIG
+        else:
+            if os.path.isfile(SYSTEM_CONFIG) or os.path.isfile(USER_CONFIG):
+                config_parser.read([SYSTEM_CONFIG, USER_CONFIG])
+            else:
+                parser.error(
+                    "neither '{0}' nor '{1}' config file "
+                    "found".format(SYSTEM_CONFIG, USER_CONFIG))
         # Section not found error
         if not config_parser.has_section(args.name):
             parser.error(
@@ -138,6 +149,8 @@ def _parse_all():
         args.dir = "{0}.{1}".format(args.file, DEFAULT_DIR_EXT)
     if not args.comment_prefix:
         args.comment_prefix = DEFAULT_COMMENT_PREFIX
+    if not args.config:
+        args.config = [SYSTEM_CONFIG, USER_CONFIG]
 
     _print_verbose(
         "Generating {0} using splitted config files from {1}...".format(


### PR DESCRIPTION
This pull request (`v0.4.0`) implements the user home config file and fixes a bug that was impossibiliting a non-privileged user of installing the project.

**Details:**
- It's possible to use a user home config file (`~/.update-conf.py.conf`);
- **Fix:** Skip copy of system config file (`/etc/update-conf.py.conf`) when installing using a non-privileged user;
- Project data in `{prefix}/share/update-conf.py`;
  - For now, only the sample config file is being put there.
