### PR TITLE
FIX 'sample/update-conf.py.conf' doesn't exist or not a regular file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ setup(
 
     # Data files
     data_files=[
-        (join("share", main.__program__), [sample_config, ]),
+        (join("share", main.__program__), [sample_config_path, ]),
     ],
 
     # Extra


### PR DESCRIPTION
This pull request fixes a bug that was ocouring in Ubuntu when trying to install the project.

When running `pip install update-conf.py` in Ubuntu, it was generating
the following error:

> 'sample/update-conf.py.conf' doesn't exist or not a regular file.

The problem is that it's necessary to pass the full path in `setup.py` files.
