### PR TITLE
FIX /etc install failing in ubuntu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,14 +104,21 @@ class InstallCommand(install):
 
     def run(self):
         result = install.run(self)
-        if os.access(main.SYSTEM_CONFIG, os.W_OK):
-            log.info("Copying {0} to {1}".format(
-                sample_config, main.SYSTEM_CONFIG))
-            shutil.copy(sample_config_path, main.SYSTEM_CONFIG)
+        etc_dir = dirname(main.SYSTEM_CONFIG)
+        # Install config file only if it does not exist yet
+        if not isfile(main.SYSTEM_CONFIG):
+            if os.access(etc_dir, os.W_OK):
+                log.info("Copying {0} to {1}".format(
+                    sample_config, main.SYSTEM_CONFIG))
+                shutil.copy(sample_config_path, main.SYSTEM_CONFIG)
+            else:
+                log.warn(
+                    "Skiping copy of {0} to {1}. You do not have write "
+                    "permission in the {2} dir.".format(
+                        sample_config, main.SYSTEM_CONFIG, etc_dir))
         else:
-            log.warn(
-                "Skiping copy of {0} to {1}. You do not have permission "
-                "to do this.".format(sample_config, main.SYSTEM_CONFIG))
+            log.info("Skipping copy of {0} to {1}. Config file already "
+                "exists.".format(sample_config, main.SYSTEM_CONFIG))
 
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -99,13 +99,16 @@ class RegisterCommand(register):
 
 
 class InstallCommand(install):
-    """Install the global config file if it exists
+    """Install the global config file
+
+    The global config file will be installed only if:
+    - The file doesn't exist yet
+    - We have write permission in the global system config dir
     """
 
     def run(self):
         result = install.run(self)
         etc_dir = dirname(main.SYSTEM_CONFIG)
-        # Install config file only if it does not exist yet
         if not isfile(main.SYSTEM_CONFIG):
             if os.access(etc_dir, os.W_OK):
                 log.info("Copying {0} to {1}".format(


### PR DESCRIPTION
This pull request fixes 2 bugs:
- In linux, `os.access(file, W_OK)` returns `False` if file doesn't exist,
  even if `os.path.dirname(file)` exists and `os.access(os.path.dirname(file), W_OK)` returns
  `True`. It is, we have write permission in the directory, but the file doesn't exist yet;
  - In MacOS, `os.access(file, W_OK)` returns `True` instead of `False`.
- We **MUSTN'T** install the config file if a previous one already exists. We must to skip this instalation.
