### PR TITLE
FIX using manifest file and generating sdist correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 Changelog
 =========
 
+0.4.2
+-----
+
+- **Fix:** More bugs while installing in Linux;
+    - `MANIFEST.in` created so the required files are now in the source distribution (used by Linux).
+
 0.4.1
 -----
 
-- **Fix:** Some bugs while installing `{prefix}/share/update-conf.py` and `/etc/update-conf.py.conf` in Linux.
+- **Fix:** Some bugs while installing in Linux;
+    - Fixed logic to install `{prefix}/share/update-conf.py` and `/etc/update-conf.py.conf`.
 
 0.4.0
 -----

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@
 # See: https://pythonhosted.org/setuptools/setuptools.html
 include samples/update-conf.py.conf
 include LICENSE
+include README.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include samples *
+include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,8 @@
-recursive-include samples *
+# From 'setuptools' docs:
+#     "Automatically include all relevant files in your source distributions,
+#     without needing to create a MANIFEST.in file"
+# However, 'samples/update-conf.py.conf' wasn't being included in sdist. We
+# don't know if it is a bug. Anyway, we're creating our 'MANIFEST.in'.
+# See: https://pythonhosted.org/setuptools/setuptools.html
+include samples/update-conf.py.conf
 include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ class SdistCommand(sdist):
 
 
 class RegisterCommand(register):
-    """Check if we're using README.rst before register in Pypi
+    """Check if we're using README.rst before registering in Pypi
     """
 
     def finalize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from os.path import abspath, dirname, join, isfile
 import shutil
 from distutils import log
 from setuptools import setup, Command
+from setuptools.command.sdist import sdist
 from setuptools.command.register import register
 from setuptools.command.install import install
 
@@ -85,6 +86,17 @@ class GenerateRstCommand(Command):
                 f.write(rst)
         finally:
             os.remove(tmp_readme_md)
+
+
+class SdistCommand(sdist):
+    """Check if we're using README.rst before creating the source dist
+    """
+
+    def finalize_options(self):
+        if not using_rst:
+            raise Exception("{} file not found".format(README_RST))
+
+        return sdist.finalize_options(self)
 
 
 class RegisterCommand(register):
@@ -201,6 +213,7 @@ setup(
     # Commands
     cmdclass={
         "generate_rst": GenerateRstCommand,
+        "sdist": SdistCommand,
         "register": RegisterCommand,
         "install": InstallCommand,
     }

--- a/update_conf_py/main.py
+++ b/update_conf_py/main.py
@@ -20,7 +20,7 @@ from ConfigParser import SafeConfigParser
 __author__ = "Rarylson Freitas"
 __email__ = "rarylson@gmail.com"
 __program__ = "update-conf.py"
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __license__ = "Revised BSD"
 
 # Consts


### PR DESCRIPTION
The pull request fixes a nug while generating the source distribution.

This distribution is still used in Linux and was generating an error while installing in some Linux distributions (like Ubuntu).

A `MANIFEST.in` file and a `SdistCommand` command were created to solve this problem.
