### PR TITLE
Minor fix (config file not being closed) and multiple improvements and more automation in the build/publish process

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-[run]
-source = update_conf_py
-
-[report]
-exclude_lines =
-    pragma: no cover
-    if __name__ == .__main__.:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,24 @@
+name: build-and-publish
+
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+"]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: python -m pip install -r requirements-dev.txt
+      - run: python setup.py sdist bdist_wheel
+      - run: make check-build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["master"]
   pull_request:
-    branches: ["master"]
 
 jobs:
   tests:
@@ -13,16 +12,17 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@master
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -r requirements-test.txt
+      - run: python -m pip install -r requirements-test.txt
       # Install `update-conf.py` script to make it available to the
       # 'test_script.py' test module.
       - run: python setup.py develop
-      - run: make check && sudo PATH=$PATH make test-with-coverage
-      - uses: coverallsapp/github-action@master
+      - run: make check
+      - run: sudo PATH=$PATH make test-with-coverage
+      - uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /venv
-/README.rst
 /tests/tmp
 /build
 /dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog
 - The global config file (`/etc/update-conf.py.conf`) is not auto-installed when running `python setup.py install` as root anymore;
 - Support to Python 2 was removed;
     - Code simplified to support only Python 3 (3.7 or newer);
-- Switching CI from Travis to GitHub Workflows
+- Switching CI from Travis to GitHub Actions
 
 0.4.5
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.0.2
+-----
+
+- **Fix:** Close config file as soon as possible 
+    - Before, we were using `readfp` and keeping the config file opened forever
+- Multiple improvements and more automation in the build/publish process
+    - Notadably, the release process now uses a CI/CD pipeline via Github Actions
+
 1.0.1
 -----
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ When creating a pull request, please follow these guidelines:
 
 - Make a pull request comparing your new branch with the project develop branch;
 - Verify if your code works for all supported Python versions;
-    - You can check [update-conf.py - GitHub - Actions](https://github.com/rarylson/update-conf.py/actions/workflows/test.yml) for troubleshooting if necessary.
+    - You can check [update-conf.py - GitHub Actions](https://github.com/rarylson/update-conf.py/actions/workflows/tests.yml) for troubleshooting if necessary.
 
 If you follow all the previous guidelines, you're really an angel :angel: :+1:!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,6 @@ When creating a pull request, please follow these guidelines:
   ```sh
   make check
   make test  # or 'sudo make test' to run all tests
-  make test-coverage
   ```
 
 - Push your changes:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,9 +11,7 @@
 # don't know if it is a bug. Anyway, we're adding it into our 'MANIFEST.in'.
 # See: https://pythonhosted.org/setuptools/setuptools.html
 #      https://docs.python.org/2/distutils/sourcedist.html
-include Makefile
 include LICENSE
-include .coveragerc
 include *.md
 include *.txt
 recursive-include samples *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,5 +19,5 @@ include *.txt
 recursive-include samples *
 recursive-include tests *
 global-exclude tests/tmp/*
-global-exclude *.rst
 global-exclude *.pyc
+exclude Makefile

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,11 @@ help:
 	@echo "Usage:"
 	@echo
 	@echo "    make install              install project in system (global)"
-	@echo "    make uninstall            show tips for uninstalling"
 	@echo "    make check                check PEP8 compliance (and others)"
 	@echo "    make test                 run tests (use 'sudo' to run all)"
 	@echo "    make check-coverage       run tests and check coverage (use 'sudo' to run all)"
 	@echo "    make clean                cleanup temporary files"
 	@echo "    make install-develop      install project in develop mode (virtual environment)"
-	@echo "    make develop-deps-ubuntu  install software dependencies (valid only in Ubuntu)"
-	@echo "    make develop-deps-macos   install software dependencies (valid only in MacOS if using Homebrew)"
 	@echo "    make prepare              prepare stuff (build, dist, etc) before publishing"
 	@echo "    make publish-test         test publishing a version (PyPI Test)"
 	@echo "    make install-pypitest     test install project (from PyPI Test)"
@@ -33,7 +30,7 @@ help:
 # Tests
 
 check:
-	CHECK_MANIFEST=True check-manifest
+	check-manifest
 # Ignore 'N802' (function name should be lowercase) in tests because we need
 # to inherit from the unittest class (that defines the setUp / tearDown
 # functions). Ignore 'W503' (line break occurred before a binary operator)
@@ -61,28 +58,11 @@ check-coverage: test-with-coverage
 
 # Install
 
-# setup.py does not have an uninstall command. We're only showing a tip.
-# See: http://stackoverflow.com/a/1550235/2530295
-uninstall:
-	@echo "'setup.py' does not have a uninstall command."
-	@echo "You can run the follow command to get a list of installed files and "
-	@echo "then removing them:"
-	@echo
-	@echo "    python setup.py install --record files.txt"
-	@echo
-	@echo "It's also a good practice using 'pip' in a production env."
-
 install: 
 	python setup.py install
 
 
 # Development
-
-develop-deps-ubuntu:
-	apt-get install -y pandoc
-
-develop-deps-macos:
-	brew install pandoc
 
 install-develop:
 	virtualenv $(VENV)
@@ -99,7 +79,6 @@ install-pypitest:
 # Publish (release)
 
 prepare:
-	python setup.py generate_rst
 	python setup.py sdist
 	python setup.py bdist_wheel
 
@@ -130,9 +109,6 @@ publish: publish-github publish-pypi after-publish-sleep check-publish
 
 # Clean
 
-clean-rst:
-	rm -f README.rst
-
 clean-build:
 	rm -Rf build/
 	rm -Rf dist/
@@ -146,4 +122,5 @@ clean-coverage-report:
 clean-pyc:
 	find . -name "*.pyc" -type f -delete
 
-clean: clean-rst clean-build clean-coverage-report clean-pyc
+clean: clean-build clean-coverage-report clean-pyc
+

--- a/Makefile
+++ b/Makefile
@@ -117,12 +117,15 @@ publish-github:
 check-publish-test:
 	pip index versions --index https://testpypi.python.org/pypi/ $(NAME) | grep -o "Available versions: $(VERSION)"
 
+after-publish-sleep:
+	sleep 30
+
 check-publish:
 	pip index versions $(NAME) | grep -o "Available versions: $(VERSION)"
 
-publish-test: publish-pypitest check-publish-test
+publish-test: publish-pypitest after-publish-sleep check-publish-test
 
-publish: publish-github publish-pypi check-publish
+publish: publish-github publish-pypi after-publish-sleep check-publish
 
 
 # Clean

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PREFIX=/usr/local
 ETC=/etc
 VENV=venv
 TEST_PACKAGE=tests
+
 VERSION=$(shell python setup.py --version)
 
 
@@ -15,19 +16,39 @@ all: help
 help:
 	@echo "Usage:"
 	@echo
-	@echo "    make install              install project in system (global)"
-	@echo "    make check                check PEP8 compliance (and others)"
-	@echo "    make test                 run tests (use 'sudo' to run all)"
-	@echo "    make check-coverage       run tests and check coverage (use 'sudo' to run all)"
-	@echo "    make clean                cleanup temporary files"
-	@echo "    make install-develop      install project in develop mode (virtual environment)"
-	@echo "    make prepare              prepare stuff (build, dist, etc) before publishing"
-	@echo "    make publish-test         test publishing a version (PyPI Test)"
-	@echo "    make install-pypitest     test install project (from PyPI Test)"
-	@echo "    make publish              publish a version (GitHub / PyPI)"
+	@echo "    make install                  install project in system (global)"
+	@echo "    make install-develop          install project in develop mode (virtual env with test and build tools)"
+	@echo "    make check                    run checks (like PEP8 compliance)"
+	@echo "    make test                     run tests (use 'sudo' to run all)"
+	@echo "    make test-with-coverage       run tests with coverage (use 'sudo' to run all)"
+	@echo "    make coverage-report          generate coverage report in html"
+	@echo "    make build                    build (sdist and bdist_wheel)"
+	@echo "    make check-and-test-publish   run checks and test the process of publishing a version (using Test PyPI)"
+	@echo "    make tag-for-publish          push tag version on GitHub (which triggers the CI/CD pipeline to publish the version on PyPI"
+	@echo "    make clean                    cleanup temporary files"
 
 
-# Tests
+# Install
+
+install:
+	python setup.py install
+
+
+# Development
+
+install-develop:
+	python3 -m venv $(VENV)
+	. $(VENV)/bin/activate && python -m pip install -r requirements-dev.txt
+	. $(VENV)/bin/activate && python setup.py develop
+	@echo
+	@echo "Environment setup done. Remember to activate your virtual env."
+	@echo
+	@tput setaf 2
+	@echo "    . $(VENV)/bin/activate"
+	@tput sgr0
+
+
+# Tests and checks
 
 check:
 	check-manifest
@@ -40,7 +61,7 @@ test-with-coverage:
 	coverage run setup.py test
 	coverage lcov
 
-check-coverage: test-with-coverage
+coverage-report:
 	coverage html
 	@echo
 	@echo "Check coverage results at"
@@ -51,66 +72,58 @@ check-coverage: test-with-coverage
 	@echo
 	cd htmlcov && python -m http.server
 
+check-build:
+	check-wheel-contents dist/*.whl
+	python -m twine check dist/*
 
-# Install
-
-install: 
-	python setup.py install
-
-
-# Development
-
-install-develop:
-	virtualenv $(VENV)
-	. $(VENV)/bin/activate && pip install --upgrade pip
-	. $(VENV)/bin/activate && pip install -r requirements-dev.txt
-	. $(VENV)/bin/activate && python setup.py develop
-
-install-pypitest:
-	virtualenv $(VENV)
-	. $(VENV)/bin/activate && pip install \
-		--index-url https://test.pypi.org/simple/ $(NAME)==$(VERSION)
+install-from-testpipy:
+	python3 -m venv $(VENV)
+	. $(VENV)/bin/activate && python -m pip install -i https://test.pypi.org/simple/ $(NAME)==$(VERSION)
 
 
-# Publish (release)
+# Build
 
-prepare:
-	python setup.py sdist
-	python setup.py bdist_wheel
+build: clean-build clean-dist
+	python setup.py sdist bdist_wheel
 
-# To use this command, you should have pypitest configured in your ~/.pypirc.
-publish-pypitest: prepare
-	twine upload --repository testpypi dist/*
 
-publish-pypi: prepare
-	twine upload dist/*
+# Test publish
 
-publish-github:
+publish-testpypi:
+	twine upload -r testpypi dist/*
+
+check-and-test-publish: build check-build publish-testpypi
+	@echo
+	@echo "Test of publishing on Test PyPI done. If necessary, remember to test install from Test PyPI."
+	@echo
+	@tput setaf 2
+	@echo "    deactivate"
+	@echo "    rm -Rf $(VENV)"
+	@echo "    make install-from-testpypi"
+	@tput sgr0
+
+
+# Tag for publish
+
+# It will trigger a CI/CD pipeline that will ending up on publishing on PyPI.
+tag-for-publish:
 	git tag "v$(VERSION)"
 	git push origin "v$(VERSION)"
-
-check-publish-test:
-	pip index versions --index https://testpypi.python.org/pypi/ $(NAME) | grep -o "Available versions: $(VERSION)"
-
-after-publish-sleep:
-	sleep 30
-
-check-publish:
-	pip index versions $(NAME) | grep -o "Available versions: $(VERSION)"
-
-publish-test: publish-pypitest after-publish-sleep check-publish-test
-
-publish: publish-github publish-pypi after-publish-sleep check-publish
 
 
 # Clean
 
 clean-build:
-	rm -Rf build/
-	rm -Rf dist/
-	rm -Rf *.egg-info
+	python setup.py clean --all
 
-clean-coverage-report:
+clean-dist:
+	rm -Rf dist
+
+clean-egg:
+	rm -Rf *.egg-info
+	rm -Rf .eggs
+
+clean-coverage:
 	rm -f .coverage
 	rm -f coverage.lcov
 	rm -Rf htmlcov
@@ -118,5 +131,4 @@ clean-coverage-report:
 clean-pyc:
 	find . -name "*.pyc" -type f -delete
 
-clean: clean-build clean-coverage-report clean-pyc
-
+clean: clean-build clean-dist clean-egg clean-coverage clean-pyc

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,7 @@ help:
 
 check:
 	check-manifest
-# Ignore 'N802' (function name should be lowercase) in tests because we need
-# to inherit from the unittest class (that defines the setUp / tearDown
-# functions). Ignore 'W503' (line break occurred before a binary operator)
-# because it's now deprecated and PEP8 is recommending the opposite.
-	flake8 --ignore=N802,W503 $(TEST_PACKAGE)
+	flake8 $(PACKAGE) $(TEST_PACKAGE)
 
 test:
 	python setup.py test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 update-conf.py
 ==============
 
-[![Test Status](https://github.com/rarylson/update-conf.py/actions/workflows/test.yml/badge.svg?branch=master&event=push)](https://github.com/rarylson/update-conf.py/actions/workflows/test.yml)
+[![Test Status](https://github.com/rarylson/update-conf.py/actions/workflows/tests.yml/badge.svg?branch=master&event=push)](https://github.com/rarylson/update-conf.py/actions/workflows/tests.yml)
 [![Coverage Status](https://coveralls.io/repos/github/rarylson/update-conf.py/badge.svg?branch=master)](https://coveralls.io/github/rarylson/update-conf.py?branch=master)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/update-conf.py.svg)](https://pypi.python.org/pypi/update-conf.py/)
 [![PyPI - Version](https://img.shields.io/pypi/v/update-conf.py.svg)](https://pypi.python.org/pypi/update-conf.py/)
@@ -22,13 +22,13 @@ This project works in Python 3 (3.7 or newer).
 
 To install:
 
-```sh
+```bash
 pip install update-conf.py
 ```
 
 It's possible to clone the project in Github and install it via `setuptools`:
 
-```sh
+```bash
 git clone git@github.com:rarylson/update-conf.py.git
 cd update-conf.py
 python setup.py install
@@ -39,7 +39,7 @@ Usage
 
 To generate a config file, you can run something like this:
 
-```sh
+```bash
 update-conf.py -f /etc/snmp/snmpd.conf
 ```
 
@@ -47,7 +47,7 @@ The example above will merge the snippets in the directory `/etc/snmp/snmpd.conf
 
 If the directory containing the snippets uses a diferent name pattern, you can pass its name as an argument:
 
-```sh
+```bash
 update-conf.py -f /etc/snmp/snmpd.conf -d /etc/snmp/snmpd.d
 ```
 
@@ -61,13 +61,13 @@ dir = /etc/snmp/snmpd.d
 
 Now, you can run:
 
-```sh
+```bash
 update-conf.py -n snmpd
 ```
 
 To get help:
 
-```sh
+```bash
 update-conf.py --help
 ```
 
@@ -77,13 +77,13 @@ update-conf.py --help
 
 You can use the the sample config file (provided within the distributed package) as a start point:
 
-```sh
-cp {prefix}/share/update-conf.py/update-conf.py.conf /etc/update-conf.py.conf
+```bash
+cp ${prefix}/share/update-conf.py/update-conf.py.conf /etc/update-conf.py.conf
 ```
 
 It's also possible to pass a custom config file via command line args:
 
-```sh
+```bash
 update-conf.py -c my_custom_config.conf -n snmpd
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ pip>=19.3
 setuptools>=46.1
 wheel>=0.34
 twine>=4.0
+
+check-wheel-contents>=0.3.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements-test.txt
 
-setuptools>=0.8
-pypandoc>=1.9
+pip>=19.3
+setuptools>=46.1
+wheel>=0.34
 twine>=4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 coverage>=6.5
 flake8>=5.0
-pep8-naming>=0.2
+pep8-naming>=0.13.2
 check-manifest>=0.22

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,11 @@
 [wheel]
 universal = 1
+
+[coverage:run]
+source = update_conf_py
+
+[coverage:report]
+show_missing = true
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [coverage:run]
 source = update_conf_py
 

--- a/setup.py
+++ b/setup.py
@@ -2,109 +2,25 @@
 """
 
 import os
-from os.path import abspath, dirname, join, isfile
-import shutil
-from distutils import log
-from setuptools import setup, Command
-from setuptools.command.egg_info import egg_info
-from setuptools.command.install import install
+from os.path import abspath, dirname, join
+from setuptools import setup
 
 from update_conf_py import main
 
+
 # Consts
 GITHUB_URL = "https://github.com/rarylson/update-conf.py"
-README_MD = "README.md"
-README_RST = "README.rst"
+README = "README.md"
 
 # Important vars
 cur_dir = abspath(dirname(__file__))
-readme_md = join(cur_dir, README_MD)
-readme_rst = join(cur_dir, README_RST)
+readme = join(cur_dir, README)
 sample_config = join("samples", main.CONFIG_NAME)
 # Get description from the first line of the module docstring.
 description = main.__doc__.split('\n')[0]
-# Get the long description from the 'README.rst' file (if it exists). Else,
-# fallback to the module docstring.
-# 'README.rst' MUST be required when generating dists or registering to PyPI.
-# In all the other cases, it's fine to use the module docstring.
 long_description = ""
-using_rst = False
-try:
-    with open(readme_rst, 'r') as f:
-        long_description = f.read()
-        using_rst = True
-except IOError:
-    long_description = main.__doc__
-# Env vars for workaround
-using_check_manifest = os.environ.get('CHECK_MANIFEST', None) == 'True'
-
-
-class GenerateRstCommand(Command):
-    """Generate a README.rst file
-
-    This file can be used after in the register command.
-    """
-
-    description = "generate a README.rst file from README.md"
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        if isfile(readme_rst):
-            os.remove(readme_rst)
-
-    def run(self):
-        import tempfile
-        import shutil
-        import re
-
-        import pypandoc
-
-        tmp_readme_md = join(tempfile.gettempdir(), README_MD)
-        shutil.copy(readme_md, tmp_readme_md)
-        try:
-            with open(tmp_readme_md, "r") as f:
-                md = f.read()
-            # Convert links that points to a relative URL
-            # The markdown file may be relative URLs (like [Page](page)).
-            # However, we do not want these links in Pypi (they will be
-            # broken). We want to replace them by absolutive URLs (like
-            # [Page]({url}/blob/master/page)).
-            # For now, the conversions are hardcoded.
-            md_link_re = r"\(LICENSE\)"
-            md_link_new = r"({0}/blob/master/LICENSE)".format(GITHUB_URL)
-            new_md = re.sub(md_link_re, md_link_new, md)
-            md_link_re = r"\(CHANGELOG\.md\)"
-            md_link_new = r"({0}/blob/master/CHANGELOG.md)".format(GITHUB_URL)
-            new_md = re.sub(md_link_re, md_link_new, new_md)
-            with open(tmp_readme_md, "w") as f:
-                f.write(new_md)
-            # Now, convert to RST
-            rst = pypandoc.convert_file(tmp_readme_md, "rst")
-            with open(readme_rst, "w") as f:
-                f.write(rst)
-        finally:
-            os.remove(tmp_readme_md)
-
-
-class EggInfoCommand(egg_info):
-    """Check if we're using README.rst before registering in PyPI or before
-    creating dists
-
-    This is necessary to avoid uploading packages / registring versions without
-    the correct 'long_description'.
-    """
-
-    def finalize_options(self):
-        if (any(x in self.distribution.commands for x in
-                ["register", "sdist", "bdist_wheel"]) and
-                not using_check_manifest):
-            if not using_rst:
-                raise Exception("{} file not found".format(README_RST))
-
-        return egg_info.finalize_options(self)
+with open(readme, 'r') as f:
+    long_description = f.read()
 
 
 # Setup
@@ -114,6 +30,7 @@ setup(
     version=main.__version__,
     description=description,
     long_description=long_description,
+    long_description_content_type="text/markdown",
     license=main.__license__,
     author=main.__author__,
     author_email=main.__email__,
@@ -123,13 +40,7 @@ setup(
     packages=["update_conf_py"],
 
     # Requirements
-    setup_requires=[
-        "setuptools>=0.8",
-    ],
-    tests_require=[
-        "setuptools>=0.8",
-        "unittest2>=1.0.0",
-    ],
+    python_requires=">=3.7",
 
     # Classifiers
     # See: https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -164,10 +75,4 @@ setup(
 
     # Tests
     test_suite="tests",
-
-    # Commands
-    cmdclass={
-        "generate_rst": GenerateRstCommand,
-        "egg_info": EggInfoCommand,
-    }
 )

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setup(
     author=main.__author__,
     author_email=main.__email__,
     url=GITHUB_URL,
-    download_url="{0}/tarball/{1}".format(GITHUB_URL, main.__version__),
-    keywords="system unix config split snippets sysadmin",
+    keywords="system unix config split merge snippets sysadmin",
     packages=["update_conf_py"],
 
     # Requirements

--- a/tests/test_sudo_config.py
+++ b/tests/test_sudo_config.py
@@ -11,10 +11,9 @@ from . import utils
 
 
 @unittest.skipIf(
-    os.geteuid() != 0, "supported only if the user is a superuser")
+    os.geteuid() != 0, "supported only with root (or sudo)")
 class SudoConfigTest(unittest.TestCase):
-    """Tests for the config read feature, but that requires superuser
-    privileges
+    """Tests for the config read feature, but that requires root privileges
 
     This tests SHOULD be run only in DEVELOPMENT envs. There are risks of
     destroying your original config files. Keep CAUTION!

--- a/update_conf_py/main.py
+++ b/update_conf_py/main.py
@@ -111,7 +111,7 @@ def _parse_all():
         # Specific config file
         if args.config:
             try:
-                config_parser.readfp(open(args.config, 'r'))
+                config_parser.read(args.config)
             except IOError:
                 parser.error("config file '{0}' not found".format(args.config))
         # Default config file

--- a/update_conf_py/main.py
+++ b/update_conf_py/main.py
@@ -20,7 +20,7 @@ from configparser import ConfigParser
 __author__ = "Rarylson Freitas"
 __email__ = "rarylson@gmail.com"
 __program__ = "update-conf.py"
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __license__ = "Revised BSD"
 
 # Consts


### PR DESCRIPTION
Main changes are:

- **Fix:** Close config file as soon as possible
    - Before, we were using `readfp` and keeping the config file opened forever
- Multiple improvements and more automation in the build/publish process
    - Notably, the release process now uses a CI/CD pipeline via GitHub Actions (`build-and-publish.yml`)
    - There are other improvements. Some relevant are:
        - The `Makefile` was considerable refactored and simplified as well
        - Bdist wheel generation is not more flagged as universal (only Python 3 support)
        - `flake8` check was improved, and build checks were added (to better validate the builds before publishing them via automation)